### PR TITLE
rozhodnutí ReS ze dne 27.6.2023

### DIFF
--- a/index.md
+++ b/index.md
@@ -280,6 +280,8 @@ Pro určení počtu místopředsedů podle tohoto ustanovení je rozhodující p
 
 1) Republikové předsednictvo sestává z předsedy a čtyř místopředsedů.
 
+    a) Místopředsedové Republikového předsednictva mohou rezignovat na svůj mandát v Republikovém předsednictvu a přitom si ponechat návazný mandát v Republikovém výboru. Volby na takto uvolněnou pozici místopředsedy Republikového předsednictva se vypisují až po vypršení takového mandátu v Republikovém výboru.
+
 2) Republikové předsednictvo:
 
     a) je statutárním a výkonným orgánem strany,


### PR DESCRIPTION
doplnit čl. 10, odst. 1 o část.

„a) Místopředsedové Republikového předsednictva mohou rezignovat na svůj mandát v Republikovém předsednictvu a přitom si ponechat návazný mandát v Republikovém výboru. Volby na takto uvolněnou pozici místopředsedy Republikového předsednictva se vypisují až po vypršení takového mandátu v Republikovém výboru.“

Odůvodnění: Jde o reakci na novou legislativu komplikující život PEP (politicky exponovaným osobám) na úrovni jejich rodin i firemních kolektivů.